### PR TITLE
Check privacy page link status

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -299,7 +299,7 @@ export default function Home() {
                 </div>
               </div>
               <h3 className="text-2xl font-bold text-[#232323] mb-2">Emerging Tech / Speculative Futures</h3>
-              <a href="/futures-lab" className="inline-block mt-2 bg-gradient-to-r from-[#e7a77e] to-[#f59e42] text-white font-semibold rounded-full px-6 py-2 transition-all duration-300 shadow hover:shadow-lg text-sm">Explore Futures Lab →</a>
+              <a href="/think-tank" className="inline-block mt-2 bg-gradient-to-r from-[#e7a77e] to-[#f59e42] text-white font-semibold rounded-full px-6 py-2 transition-all duration-300 shadow hover:shadow-lg text-sm">Explore Futures Lab →</a>
             </div>
           </div>
         </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Privacy Policy | Ukiyo Habitat",
+  description: "Read the privacy policy of Ukiyo Habitat to understand how we collect, use, and protect your information.",
+};
+
+export default function PrivacyPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <h1 className="text-3xl sm:text-4xl font-bold text-[#232323] mb-6">Privacy Policy</h1>
+      <p className="text-[#6b7280] mb-4">
+        We value your privacy. This page outlines how Ukiyo Habitat collects, uses, and safeguards your personal information.
+      </p>
+      <div className="space-y-4 text-[#6b7280] leading-relaxed">
+        <p>
+          - We only collect information necessary to provide our services and improve your experience.
+        </p>
+        <p>
+          - We do not sell your personal data. We may share it with trusted service providers strictly to operate our services.
+        </p>
+        <p>
+          - You can contact us at <a href="mailto:hello@ukiyohabitat.com" className="text-[#e7a77e] hover:underline">hello@ukiyohabitat.com</a> for any privacy-related questions.
+        </p>
+      </div>
+    </main>
+  );
+}

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Terms of Service | Ukiyo Habitat",
+  description: "Review the terms and conditions for using Ukiyo Habitat services and website.",
+};
+
+export default function TermsPage() {
+  return (
+    <main className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+      <h1 className="text-3xl sm:text-4xl font-bold text-[#232323] mb-6">Terms of Service</h1>
+      <p className="text-[#6b7280] mb-4">
+        By accessing or using our website and services, you agree to the following terms and conditions.
+      </p>
+      <div className="space-y-4 text-[#6b7280] leading-relaxed">
+        <p>
+          - The content on this site is provided for general information and may change without notice.
+        </p>
+        <p>
+          - Unauthorized use of this website may give rise to a claim for damages and/or be a criminal offense.
+        </p>
+        <p>
+          - For questions, contact us at <a href="mailto:hello@ukiyohabitat.com" className="text-[#e7a77e] hover:underline">hello@ukiyohabitat.com</a>.
+        </p>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
Add privacy and terms pages, and update the "Explore Futures Lab" button link to `/think-tank`.

The privacy and terms links in the footer were broken (404ing) because the corresponding pages did not exist. This PR adds minimal pages to resolve that issue. The "Explore Futures Lab" button was updated to point to the correct `/think-tank` route as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-e23e5726-bc24-4899-83dc-51fbc0c79a23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e23e5726-bc24-4899-83dc-51fbc0c79a23">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

