### PR TITLE
Investigate dead google search link

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = 'https://ukiyohabitat.com';
+  const baseUrl = 'https://www.ukiyohabitat.com';
   
   return {
     rules: [

--- a/src/app/schedule-a-consultation-call/route.ts
+++ b/src/app/schedule-a-consultation-call/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+	return new NextResponse('This page has been permanently removed.', {
+		status: 410,
+		headers: {
+			'Cache-Control': 'public, max-age=3600',
+		},
+	});
+}
+
+export async function HEAD() {
+	return new NextResponse(null, { status: 410 });
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
-  const baseUrl = 'https://ukiyohabitat.com';
+  const baseUrl = 'https://www.ukiyohabitat.com';
   const currentDate = new Date();
 
   // Static pages


### PR DESCRIPTION
Align sitemap/robots base URL to www and add 410 handler for removed consultation page to improve SEO.

The `https://www.ukiyohabitat.com/schedule-a-consultation-call` URL was appearing in Google search results as a dead link (404). This PR explicitly returns a 410 Gone status for that path, signaling to search engines that the page has been permanently removed and should be de-indexed faster. Additionally, the `baseUrl` in `sitemap.ts` and `robots.ts` has been updated to the canonical `https://www.ukiyohabitat.com` to ensure consistent SEO signals.

---
<a href="https://cursor.com/background-agent?bcId=bc-afa4ce60-5a1d-40fa-a242-9d3714a6fda6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-afa4ce60-5a1d-40fa-a242-9d3714a6fda6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

